### PR TITLE
fix: pass provider options through to API request body for Anthropic extended thinking

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -174,6 +174,12 @@ export namespace ProviderTransform {
         result["reasoningSummary"] = "auto"
       }
     }
+
+    // Merge provider-specific options from config
+    if (providerOptions) {
+      return { ...providerOptions, ...result }
+    }
+
     return result
   }
 

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -3,6 +3,41 @@ import { ProviderTransform } from "../../src/provider/transform"
 
 const OUTPUT_TOKEN_MAX = 32000
 
+describe("ProviderTransform.options", () => {
+  test("merges providerOptions into result", () => {
+    const providerOptions = {
+      thinking: {
+        type: "enabled",
+        budgetTokens: 20000,
+      },
+    }
+    const result = ProviderTransform.options(
+      "anthropic",
+      "claude-opus-4-5",
+      "@ai-sdk/anthropic",
+      "session-123",
+      providerOptions,
+    )
+    expect(result.thinking).toEqual({
+      type: "enabled",
+      budgetTokens: 20000,
+    })
+  })
+
+  test("computed options take precedence over providerOptions", () => {
+    const providerOptions = {
+      promptCacheKey: "user-provided-key",
+    }
+    const result = ProviderTransform.options("openai", "gpt-4", "@ai-sdk/openai", "session-123", providerOptions)
+    expect(result.promptCacheKey).toBe("session-123")
+  })
+
+  test("returns only computed options when providerOptions is undefined", () => {
+    const result = ProviderTransform.options("openai", "gpt-4", "@ai-sdk/openai", "session-123")
+    expect(result.promptCacheKey).toBe("session-123")
+  })
+})
+
 describe("ProviderTransform.maxOutputTokens", () => {
   test("returns 32k when modelLimit > 32k", () => {
     const modelLimit = 100000


### PR DESCRIPTION
## Summary

- Fixes bug where `provider.anthropic.options.thinking` config was not being passed to the Anthropic API request body
- The `thinking` configuration (with `budget_tokens`) is now correctly included in API requests, enabling extended thinking for Claude models

## Problem

When configuring extended thinking via config:
```json
{
  "provider": {
    "anthropic": {
      "options": {
        "thinking": {
          "type": "enabled",
          "budgetTokens": 20000
        }
      }
    }
  }
}
```

The `thinking` object was being dropped in `ProviderTransform.options()` - the beta header was set correctly but the request body was missing the thinking config.

## Fix

Merge `providerOptions` into the result at the end of `options()` function, ensuring all provider-specific config flows through to the AI SDK.

## Testing

Added 3 new tests for `ProviderTransform.options()`:
- Verifies thinking config flows through
- Ensures computed options take precedence over user config
- Backward compatibility when no providerOptions provided

